### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The current CI runs on Ubuntu and it fails because well... you're trying to build a Windows application on Linux. This fixes it by changing the `runs-on` option to `windows-latest`